### PR TITLE
Wrong $httpRootDir

### DIFF
--- a/Engine/Asset.php
+++ b/Engine/Asset.php
@@ -87,7 +87,7 @@ class Asset
     {
         $publicDir = str_replace('\\', '/', $this->kernel->getProjectDir()) . '/public';
         $basePath = $this->router->getContext()->getBaseUrl();
-        $httpRootDir = str_replace($basePath, '', $publicDir);
+        $httpRootDir = substr($publicDir,0,-strlen($basePath));
 
         // return immediately for straight asset paths
         $path = s($path);


### PR DESCRIPTION
> str_replace — Replace all occurrences of the search string with the replacement string

My http root directory is ```/home/usr/public_html/```
public folder is ```/home/usr/public_html/public```

str_replace replacing ```/public``` from and making it like ```/home/usr_html``` which is wrong.

```php
$httpRootDir = substr($publicDir,0,-strlen($basePath));
```

This solution is working for me